### PR TITLE
Change architecture to any

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Standards-Version: 3.9.6
 Build-Depends: debhelper (>= 9), autoconf, zlib1g-dev, libpopt-dev, libacl1-dev, libattr1-dev
 
 Package: rsync-bpc
-Architecture: amd64
+Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: high-performance, enterprise-grade system for backing up PCs
  BackupPC is disk based and not tape based. This particularity allows


### PR DESCRIPTION
Change arch from amd64 to any to enable building on arm devices

Previously rsync-bpc would not build on raspberry pi, changing architecture to any fixes this